### PR TITLE
Fixed bug in return of pitch values in select function in swipe.i

### DIFF
--- a/swipe.i
+++ b/swipe.i
@@ -164,7 +164,7 @@ class Swipe(object):
         """
         if tmin or tmax:
             (i, j) = self._bisect(tmin, tmax)
-            return zip(self.t[i:j], self.p[i,j])
+            return zip(self.t[i:j], self.p[i:j])
         else:
             raise ValueError, 'tmin and/or tmax must be defined'
 


### PR DESCRIPTION
The return value of the select function in swipe.i contained a bug in the pitch values range. This
has been fixed in this commit.