### PR TITLE
Fixed batch mode segfault and write errors

### DIFF
--- a/swipe.c
+++ b/swipe.c
@@ -567,8 +567,8 @@ swipe [-i FILE] [-o FILE] [-b LIST] [-r MIN:MAX] [-s TS] [-t DT] [-mnhv]\n\
     }
     if (batch != NULL) { 
         // iterate through batch pairs
-        wav = (char *) malloc(1024*sizeof(char));
-        out = (char *) malloc(1024*sizeof(char));
+        char wav[1024];
+        char out[1024];
         while (fscanf(batch, "%1023s %1023s", wav, out) != EOF) {
             printf("%s -> %s...", wav, out);
             FILE* wf = fopen(wav, "r");
@@ -596,8 +596,6 @@ swipe [-i FILE] [-o FILE] [-b LIST] [-r MIN:MAX] [-s TS] [-t DT] [-mnhv]\n\
             freev(p);
         }
         fclose(batch);
-        free(wav);
-        free(out);
     }
     else {
         vector p;

--- a/swipe.c
+++ b/swipe.c
@@ -569,7 +569,7 @@ swipe [-i FILE] [-o FILE] [-b LIST] [-r MIN:MAX] [-s TS] [-t DT] [-mnhv]\n\
         // iterate through batch pairs
         wav = (char *) malloc(1024*sizeof(char));
         out = (char *) malloc(1024*sizeof(char));
-        while (fscanf(batch, "%s %s", wav, out) != EOF) {
+        while (fscanf(batch, "%1023s %1023s", wav, out) != EOF) {
             printf("%s -> %s...", wav, out);
             FILE* wf = fopen(wav, "r");
             if (wf == NULL) {

--- a/swipe.c
+++ b/swipe.c
@@ -452,7 +452,8 @@ void printp(vector p, int fid, double dt, int mel, int vlo) {
                 t += dt;
             }
         }
-    } 
+    }
+    fflush(sink);
 }
 
 // main method, interfacing with user arguments
@@ -566,6 +567,8 @@ swipe [-i FILE] [-o FILE] [-b LIST] [-r MIN:MAX] [-s TS] [-t DT] [-mnhv]\n\
     }
     if (batch != NULL) { 
         // iterate through batch pairs
+        wav = (char *) malloc(1024*sizeof(char));
+        out = (char *) malloc(1024*sizeof(char));
         while (fscanf(batch, "%s %s", wav, out) != EOF) {
             printf("%s -> %s...", wav, out);
             FILE* wf = fopen(wav, "r");
@@ -593,6 +596,8 @@ swipe [-i FILE] [-o FILE] [-b LIST] [-r MIN:MAX] [-s TS] [-t DT] [-mnhv]\n\
             freev(p);
         }
         fclose(batch);
+        free(wav);
+        free(out);
     }
     else {
         vector p;


### PR DESCRIPTION
Currently, running batch mode leads to a segfault as both `wav` and `out` are not allocated beyond a single null terminator, so `fscanf` in the main loop of batch mode leads to a buffer overflow. I fixed this by allocating some memory for both strings. 

Additionally, after fixing this I found that many files would just get empty files after running batch mode, this is because the files were closed before they were written to, I fixed this by fflushing at the end of `printp`